### PR TITLE
feat: add clickable block height links to block explorer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { makeVstorageKit } from '@agoric/client-utils';
 import type { StreamCell } from '@agoric/internal/src/lib-chainStorage.js';
 
 import './App.css';
+import { getBlockExplorerUrl } from './utils';
 
 const updateQueryParam = (key: string, value: string) => {
   const params = new URLSearchParams(window.location.search);
@@ -248,7 +249,18 @@ const App = () => {
           </Typography>
           <Box sx={{ display: 'flex', alignItems: 'center', mr: 2 }}>
             <Typography variant="body1" sx={{ mr: 2 }}>
-              Height: {currentBlockHeight}
+              Height: {currentBlockHeight && getBlockExplorerUrl(apiEndpoint, currentBlockHeight) ? (
+                <a 
+                  href={getBlockExplorerUrl(apiEndpoint, currentBlockHeight)} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  style={{ color: 'inherit', textDecoration: 'underline' }}
+                >
+                  {currentBlockHeight}
+                </a>
+              ) : (
+                currentBlockHeight
+              )}
             </Typography>
             <IconButton
               onClick={() => {
@@ -365,7 +377,7 @@ const App = () => {
               <ContentCopyIcon />
             </IconButton>
           </Tooltip>
-          {cell && <ContentPane {...cell} />}
+          {cell && <ContentPane {...cell} apiEndpoint={apiEndpoint} />}
         </Box>
       </SplitPane>
       <Box

--- a/src/ContentPane.tsx
+++ b/src/ContentPane.tsx
@@ -2,13 +2,15 @@ import React, { useState, ChangeEvent } from 'react';
 import { Box, Switch, FormControlLabel } from '@mui/material';
 import ReactJson from 'react-json-view';
 import { decodeValues } from './api.js';
+import { getBlockExplorerUrl } from './utils';
 
 interface ContentPaneProps {
   blockHeight: string | null; // Allow null for 'Latest'
   values: string[] | null; // Allow null if no values
+  apiEndpoint: string;
 }
 
-const ContentPane: React.FC<ContentPaneProps> = ({ blockHeight, values }) => {
+const ContentPane: React.FC<ContentPaneProps> = ({ blockHeight, values, apiEndpoint }) => {
   console.debug('ContentPane', { blockHeight, values });
   const [showRaw, setShowRaw] = useState(false);
 
@@ -48,7 +50,18 @@ const ContentPane: React.FC<ContentPaneProps> = ({ blockHeight, values }) => {
         padding={2}
         style={{ whiteSpace: 'pre-wrap' }}
       >
-        Block: <tt>{blockHeight || 'Latest'}</tt>
+        Block: <tt>{blockHeight && blockHeight !== 'Latest' && getBlockExplorerUrl(apiEndpoint, parseInt(blockHeight)) ? (
+          <a 
+            href={getBlockExplorerUrl(apiEndpoint, parseInt(blockHeight))} 
+            target="_blank" 
+            rel="noopener noreferrer"
+            style={{ color: 'inherit', textDecoration: 'underline' }}
+          >
+            {blockHeight}
+          </a>
+        ) : (
+          blockHeight || 'Latest'
+        )}</tt>
       </Box>
 
       {/* Toggle Switch */}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export const getBlockExplorerUrl = (endpoint: string, blockHeight: number): string => {
+  // Extract network prefix from RPC endpoint
+  const match = endpoint.match(/https:\/\/(.*?)\.rpc\.agoric\.net/);
+  if (match) {
+    const networkPrefix = match[1];
+    // Special case for mainnet which uses 'followmain' in explorer
+    const explorerPrefix = networkPrefix === 'main-a' ? 'followmain' : networkPrefix;
+    return `https://${explorerPrefix}.explorer.agoric.net/agoric/block/${blockHeight}`;
+  }
+  return '';
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ export const getBlockExplorerUrl = (endpoint: string, blockHeight: number): stri
   if (match) {
     const networkPrefix = match[1];
     // Special case for mainnet which uses 'followmain' in explorer
-    const explorerPrefix = networkPrefix === 'main-a' ? 'followmain' : networkPrefix;
+    const explorerPrefix = networkPrefix.startsWith('main') ? 'followmain' : networkPrefix;
     return `https://${explorerPrefix}.explorer.agoric.net/agoric/block/${blockHeight}`;
   }
   return '';


### PR DESCRIPTION
## Summary
- Make block height clickable in both header and content pane
- Add dynamic block explorer URL generation based on network endpoint  
- Support all Agoric networks (devnet, emerynet, mainnet, xnet, ollinet)
- Links open in new tab with proper security attributes

## Changes
- Created shared utility function for block explorer URL generation
- Updated App.tsx to make header block height clickable
- Updated ContentPane.tsx to make data pane block height clickable
- Added proper network prefix detection with mainnet special case handling

## Test plan
- [ ] Test block height links on devnet
- [ ] Test block height links on emerynet  
- [ ] Test block height links on mainnet
- [ ] Verify links open in new tab
- [ ] Confirm "Latest" blocks show as non-clickable text
- [ ] Test localhost endpoints don't generate invalid links

🤖 Generated with [Claude Code](https://claude.ai/code)